### PR TITLE
Add double quote marks around the hash symbol

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function($){
 
 	// Disable click on empty hrefs
-	$( 'a[href=#]' ).not( $( '#wpadminbar a' ) ).click(function(){
+	$( 'a[href="#"]' ).not( $( '#wpadminbar a' ) ).click(function(){
 		return false;
 	});
 


### PR DESCRIPTION
This will fix the JavaScript error when using WordPress 4.5 and newer jQuery library.